### PR TITLE
Make WaifReference frozen/hashable for use as map keys

### DIFF
--- a/lambdamoo_db/database.py
+++ b/lambdamoo_db/database.py
@@ -133,8 +133,9 @@ class Waif:
     propdefs_length: int = attrs.field(default=0)  # Original propdefs_length for roundtrip
 
 
-@attrs.define()
+@attrs.define(frozen=True)
 class WaifReference:
+    """Reference to a waif by index. Frozen to be hashable (used as map keys)."""
     index: int
 
 


### PR DESCRIPTION
## Summary
- Make WaifReference a frozen dataclass to enable hashability
- MOO maps can have WaifReference as keys, requiring this change

## Test plan
- Verify WaifReference can be used as dictionary keys
- Verify existing database roundtrip tests still pass